### PR TITLE
added IDE settings for CLion Coding Style

### DIFF
--- a/IDESettings/CLion/CRP_CLion2016_1.xml
+++ b/IDESettings/CLion/CRP_CLion2016_1.xml
@@ -1,0 +1,126 @@
+<code_scheme name="CRP">
+  <option name="RIGHT_MARGIN" value="80" />
+  <option name="FORMATTER_TAGS_ACCEPT_REGEXP" value="true" />
+  <Objective-C>
+    <option name="KEEP_NESTED_NAMESPACES_IN_ONE_LINE" value="true" />
+    <option name="NAMESPACE_BRACE_PLACEMENT" value="2" />
+    <option name="FUNCTION_BRACE_PLACEMENT" value="2" />
+    <option name="BLOCK_BRACE_PLACEMENT" value="2" />
+    <option name="FUNCTION_PARAMETERS_WRAP" value="2" />
+    <option name="FUNCTION_PARAMETERS_ALIGN_MULTILINE" value="false" />
+    <option name="FUNCTION_PARAMETERS_NEW_LINE_AFTER_LPAR" value="true" />
+    <option name="FUNCTION_PARAMETERS_NEW_LINE_BEFORE_RPAR" value="true" />
+    <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="2" />
+    <option name="FUNCTION_CALL_ARGUMENTS_ALIGN_MULTILINE" value="false" />
+    <option name="FUNCTION_CALL_ARGUMENTS_NEW_LINE_AFTER_LPAR" value="true" />
+    <option name="FUNCTION_CALL_ARGUMENTS_NEW_LINE_BEFORE_RPAR" value="true" />
+    <option name="TEMPLATE_PARAMETERS_WRAP" value="2" />
+    <option name="TEMPLATE_PARAMETERS_NEW_LINE_AFTER_LT" value="true" />
+    <option name="TEMPLATE_PARAMETERS_NEW_LINE_BEFORE_GT" value="true" />
+    <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="2" />
+    <option name="TEMPLATE_CALL_ARGUMENTS_NEW_LINE_AFTER_LT" value="true" />
+    <option name="TEMPLATE_CALL_ARGUMENTS_NEW_LINE_BEFORE_GT" value="true" />
+    <option name="CLASS_CONSTRUCTOR_INIT_LIST_WRAP" value="2" />
+    <option name="CLASS_CONSTRUCTOR_INIT_LIST_ALIGN_MULTILINE" value="false" />
+    <option name="CLASS_CONSTRUCTOR_INIT_LIST_NEW_LINE_BEFORE_COLON" value="0" />
+    <option name="CLASS_CONSTRUCTOR_INIT_LIST_NEW_LINE_AFTER_COLON" value="1" />
+    <option name="SUPERCLASS_LIST_WRAP" value="2" />
+    <option name="SUPERCLASS_LIST_ALIGN_MULTILINE" value="false" />
+    <option name="SUPERCLASS_LIST_BEFORE_COLON" value="0" />
+    <option name="SUPERCLASS_LIST_AFTER_COLON" value="1" />
+    <option name="SPACE_WITHIN_TEMPLATE_DECLARATION_LTGT" value="true" />
+    <option name="SPACE_WITHIN_EMPTY_TEMPLATE_DECLARATION_LTGT" value="true" />
+    <option name="SPACE_WITHIN_TEMPLATE_CALL_LTGT" value="true" />
+    <option name="SPACE_WITHIN_EMPTY_TEMPLATE_CALL_LTGT" value="true" />
+    <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false" />
+    <option name="SPACE_WITHIN_FUNCTION_DECLARATION_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_EMPTY_FUNCTION_DECLARATION_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_FUNCTION_CALL_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_EMPTY_FUNCTION_CALL_PARENTHESES" value="true" />
+    <option name="SPACE_BEFORE_INIT_LIST" value="true" />
+    <option name="SPACE_AFTER_POINTER_IN_DECLARATION" value="true" />
+    <option name="SPACE_AFTER_REFERENCE_IN_DECLARATION" value="true" />
+    <option name="SPACE_BETWEEN_ADJACENT_BRACKETS" value="true" />
+    <option name="DISCHARGED_SHORT_TERNARY_OPERATOR" value="true" />
+    <option name="INTRODUCE_AUTO_VARS" value="true" />
+  </Objective-C>
+  <Objective-C-extensions>
+    <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
+    <option name="RELEASE_STYLE" value="IVAR" />
+    <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
+    <file>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+    </file>
+    <class>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+    </class>
+    <extensions>
+      <pair source="cpp" header="hpp" />
+      <pair source="c" header="h" />
+    </extensions>
+  </Objective-C-extensions>
+  <XML>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
+  <codeStyleSettings language="CMake">
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+  </codeStyleSettings>
+  <codeStyleSettings language="ObjectiveC">
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+    <option name="BLANK_LINES_BEFORE_IMPORTS" value="2" />
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
+    <option name="BLANK_LINES_AROUND_METHOD" value="2" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="CLASS_BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="false" />
+    <option name="SPACE_WITHIN_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_CAST_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+    <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
+    <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
+    <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
+    <option name="SPACE_BEFORE_CATCH_PARENTHESES" value="false" />
+    <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="2" />
+    <option name="BINARY_OPERATION_WRAP" value="5" />
+    <option name="TERNARY_OPERATION_WRAP" value="5" />
+    <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="false" />
+    <option name="FOR_STATEMENT_WRAP" value="5" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="2" />
+    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+    <option name="ASSIGNMENT_WRAP" value="5" />
+    <option name="IF_BRACE_FORCE" value="1" />
+    <option name="DOWHILE_BRACE_FORCE" value="1" />
+    <option name="WHILE_BRACE_FORCE" value="1" />
+    <option name="FOR_BRACE_FORCE" value="1" />
+    <option name="ENUM_CONSTANTS_WRAP" value="2" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="SMART_TABS" value="true" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>

--- a/IDESettings/README.md
+++ b/IDESettings/README.md
@@ -1,0 +1,13 @@
+# Code Style Settings for IDEs
+
+## CLion
+The XML files contain settings for different CLion versions (currently only CLion2016.1.1) that come rather close to our C++ coding guidelines. To install, import the file in CLion through  
+`File -> Settings -> Editor -> Code Style -> Manage... -> Import...`
+
+ - [CLion2016.1.1](CLion/CRP_2016_1.xml)  
+
+## Netbeans
+ (to do)
+
+## Eclipse
+ (to do)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Contributing to ComputationalRadiationPhysics Repositories
 # Quick Links
 
 - [C++ Coding Guidelines](codingGuideLines/cpp.md)
+- [C++ Code Style for current CLion](IDESettings/CLion/CRP_CLion2016_1.xml)


### PR DESCRIPTION
This adds the coding-style scheme I use for CLion right now. It gets many things right, but not the whole coding style is currently supported.

most important drawbacks (and workarounds):
 - Nesting of namespaces is either all or nothing. It isn't possible to indent only the inner-most level of nested namespaces. Can be worked aroud by putting all namespaces on a single line like `namespace A{ namespace B{ ...`  
 - two angle brackets for a template (without a space: `std::vector<A<int>>`) are not correctly detected when reformatting. Can be worked around by always placing the old-style space inbetween: `std::vector<A<int> >`  
 - putting return types and const-modifiers on separate lines is not automatically possible. Can be worked around by doing it manually