### PR TITLE
Fixed example for function definiton

### DIFF
--- a/codingGuideLines/cpp.md
+++ b/codingGuideLines/cpp.md
@@ -291,8 +291,11 @@ size( ) const
   - the function / method body `{ }` is followed by an empty line
 ```C++
 __device__ static
-const int
-incrementValue( int const & a )
+auto
+incrementValue(
+    int & a
+)
+-> int
 {
     return a++;
 } // followed by an empty line


### PR DESCRIPTION
The example code did not actually conform to the following rules:

 - `auto` return type
 - trailing return type syntax
 - newline after oc-token
 - closing oc-token on new line

Furthermore:
 - the function returns a `const int`. AFAIK there is no defined semantic
   for const-qualifiers in the return-type. This only adds noise and produces
   warnings. Was removed.
 - if there should be a `const`-qualifier for a METHOD, this should come
   after the   oc-token `)`, as in the example 5 lines above? But
   probably no `const`-qualifier, since the method is static and `const`
   is not really useful here because we don't have an object instance.
 - the function takes a `const`-reference as argument and then casually
   increments it. This will not compile.