### PR TITLE
[WIP] clang-format

### DIFF
--- a/IDESettings/.clang-format
+++ b/IDESettings/.clang-format
@@ -1,0 +1,116 @@
+---
+Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignEscapedNewlinesLeft: true
+AlignOperands: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakStringLiterals: true
+ColumnLimit: 80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - ForEach
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^"picongpu/'
+    Priority:        1
+  - Regex:           '^(\<|")pmacc/'
+    Priority:        2
+  - Regex:           '^\<(cupla|alpaka)/'
+    Priority:        3
+  - Regex:           '^\<(boost)/'
+    Priority:        4
+  - Regex:           '^\<(splash|adios|isaac|openpmd)/'
+    Priority:        5
+  - Regex:           '<[[:alnum:].]+>'
+    Priority:        6
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+PenaltyBreakAssignment: 4
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Middle
+RawStringFormats:
+  - Delimiter:       pb
+    Language:        TextProto
+    BasedOnStyle:    google
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+# SpaceBeforeCpp11BracedList: false
+# SpaceBeforeCtorInitializerColon: true
+# SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+# SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1  # Axel: I actually like "2" as in Python here
+SpacesInAngles: true
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: true
+SpacesInParentheses: true
+SpacesInSquareBrackets: true
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never
+...

--- a/IDESettings/README.md
+++ b/IDESettings/README.md
@@ -1,3 +1,12 @@
+# Code Style Configuration for Auto-Formatter
+
+## clang-format
+
+The `.clang-format` file is usually placed in the root of a project.
+Then execute `clang-format -i file.cpp` for in-place auto-formatting.
+
+- [clang-format 6.0](.clang-format)
+
 # Code Style Settings for IDEs
 
 ## CLion


### PR DESCRIPTION
Draft of a `.clang-format` rule for our projects, based on `clang-format 6.0+`.

CC @psychocoderHPC, @C0nsultant, @BenjaminW3 https://github.com/ComputationalRadiationPhysics/alpaka/issues/419

## Most Important Limitations

- `AlignAfterOpenBracket/BinPack*`: multi-parameter breaks for N>1 (template, function param, init lists, etc.) do not support 1-element-per-line; closing bracket on newline missing (H)
- `NamespaceIndentation: Inner` is not exactly what we do (+)
- double-newline after include blocks is not enforced, but `MaxEmptyLinesToKeep: 2` keeps it
- can not enforce empty newlines between function/class, etc. blocks: [SO](https://stackoverflow.com/questions/27121457/line-breaks-between-function-definitions)
- `IndentPPDirectives: Hash`: works but does not count the hash as space (+)
- `desc.add_options()()()...` syntax in `boost::program_options` looks weird - but we should switch to, e.g. [CL11](https://github.com/CLIUtils/CLI11) anyway: https://github.com/ComputationalRadiationPhysics/picongpu/issues/2421

(H) probably some work to add & upstream but quite central in our style
(+) easy to add, maybe something to upstream?

## Misc Notes

- the `IncludeCategories:` block is project specific, example is shown for PIConGPU
- online tool: https://zed0.co.uk/clang-format-configurator/ (currently not up-to-date with clang 6.0: https://github.com/zed0/clang-format-configurator/issues/15)

- references: https://clang.llvm.org/docs/ClangFormat.html https://clang.llvm.org/docs/ClangFormatStyleOptions.html