### PR TITLE
Mention multi-level pointers in 'Variable Declarations'

### DIFF
--- a/codingGuideLines/cpp.md
+++ b/codingGuideLines/cpp.md
@@ -283,6 +283,7 @@ int const * const foo; // const pointer to const int value
 int * const foo; // const pointer to int value
 int * foo; // pointer to int value
 int ** foo;  // pointer to a pointer to int value
+int * const * foo; // pointer to a const pointer to int value
 int* foo; // NOT ALLOWED by the coding guide lines (missing spaces around `*`)
 for( auto && e : vector ) // universal references are packed
 {

--- a/codingGuideLines/cpp.md
+++ b/codingGuideLines/cpp.md
@@ -273,16 +273,18 @@ foo( )
 
 
 ## 10. Variable Declarations
-  - the type qualifier `const` is placed right hand of the type that shall be const
+  - the type qualifier `const` is placed *right* hand of the type that shall be const
     - note: `constexpr` is *not* a type qualifier, but an *expression qualifier*, write it *left* of the type!
   - `&` (reference), `&&` (universal reference), and `*` (pointer) **must** be surrounded by **one** space
+    - note: multi-level pointers are **packed** though
 ```C++
 int const * foo;  // pointer to const int value
 int const * const foo; // const pointer to const int value
 int * const foo; // const pointer to int value
 int * foo; // pointer to int value
+int ** foo;  // pointer to a pointer to int value
 int* foo; // NOT ALLOWED by the coding guide lines (missing spaces around `*`)
-for( auto && e : vector )
+for( auto && e : vector ) // universal references are packed
 {
 }
 


### PR DESCRIPTION
Though what about `const`? I assume its

```c++
int * const * foo; // pointer to a const pointer to int value
```