### PR TITLE
[clang-tidy] Code style options

### DIFF
--- a/formatting-tools/.clang-tidy
+++ b/formatting-tools/.clang-tidy
@@ -1,5 +1,20 @@
-Checks: 'readability-identifier-naming'
+Checks: 'modernize-raw-string-literal,
+modernize-return-braced-init-list,
+modernize-unary-static-assert,
+modernize-use-auto,
+modernize-use-using,
+readability-identifier-naming,
+readability-isolate-declaration,
+readability-misplaced-array-index,
+readability-redundant-declaration,
+readability-redundant-function-ptr-dereference,
+readability-redundant-preprocessor,
+readability-simplify-boolean-expr,
+readability-simplify-subscript-expr'
 CheckOptions:
+  - { key: modernize-use-auto.MinTypeNameLength, value: 0}
+  - { key: modernize-use-auto.RemoveStars, value: 0}
+  - { key: modernize-use-using.IgnoreMacros, value: 0}
   - { key: readability-identifier-naming.AbstractClassCase, value: CamelCase}
   - { key: readability-identifier-naming.AggressiveDependentMemberLookup, value: 1}
   - { key: readability-identifier-naming.ClassCase, value: CamelCase}
@@ -51,3 +66,6 @@ CheckOptions:
   - { key: readability-identifier-naming.ValueTemplateParameterCase, value: CamelCase}
   - { key: readability-identifier-naming.VariableCase, value: lower_case}
   - { key: readability-identifier-naming.VirtualMethodCase, value: lower_case}
+  - { key: readability-redundant-declaration.IgnoreMacros, value: 0}
+  - { key: readability-simplify-boolean-expr.ChainedConditionalAssignment, value: 1}
+  - { key: readability-simplify-boolean-expr.ChainedConditionalReturn, value: 1}


### PR DESCRIPTION
This PR introduces a few additional checks for our code style. The voting for this PR will be closed on **Tuesday, 03 November 2020, 18:00 HZDR time**.

With the options in this proposal clang-tidy will check for the following cases:

* Unnecessarily complicated string literals ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/modernize-raw-string-literal.html))
* Not returning braced init lists ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/modernize-return-braced-init-list.html))
* `static_assert` with empty string literal ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/modernize-unary-static-assert.html))
* Not using `auto` (the `*` is left in place to identify pointers) ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html))
* `typedef` instead of `using` ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-using.html))
* Forbidden headers - this should be project-specific. For the sake of this proposal I added the boost includes ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/portability-restrict-system-includes.html))
* SIMD intrinsics instead of `std::simd` ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/portability-simd-intrinsics.html))
* Multiple declarations on a single line ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-isolate-declaration.html))
* Magic numbers instead of symbolic constants ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-magic-numbers.html))
* Unconventional array notation ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-misplaced-array-index.html))
* Redundant variable/function declarations ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-declaration.html))
* Redundant function pointer dereferencing ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-function-ptr-dereference.html))
* Redundant preprocessor directives ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-preprocessor.html))
* Unnecessarily complicated boolean expressions ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-simplify-boolean-expr.html))
* Unnecessarily complicated subscript expressions ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-simplify-subscript-expr.html))
* Not writing literal suffixes in upper case ([Documentation](https://clang.llvm.org/extra/clang-tidy/checks/readability-uppercase-literal-suffix.html))

Use the following template for the vote. If you want to keep an option but change its behaviour add an additional **column** next to `Disable`.

```markdown
Option | Enable | Disable |
-------|--------|---------|
String literals | 0 | 0 |
Braced init lists | 0 | 0 |
Unary `static_assert` | 0 | 0 |
always `auto` | 0 | 0 |
always `using` | 0 | 0 |
Forbidden headers | 0 | 0 |
`std::simd` | 0 | 0 |
Isolated declarations | 0 | 0 |
No magic numbers | 0 | 0 |
Unconventional array notation | 0 | 0 |
Redundant declarations | 0 | 0 |
Redundant function pointer dereferencing | 0 | 0 |
Redundant preprocessor | 0 | 0 |
Simple booleans | 0 | 0 |
Simple subscript | 0 | 0 |
Uppercase suffixes | 0 | 0 |
```

**VOTE**
Option | Enable | Disable |
-------|--------|---------|
String literals | 1 | 0 |
Braced init lists | 1 | 0 |
Unary `static_assert` | 1 | 0 |
always `auto` | 1 | 0 |
always `using` | 1 | 0 |
Forbidden headers | 1 | 0 |
`std::simd` | 0 | 1 |
Isolated declarations | 1 | 0 |
No magic numbers | 1 | 0 |
Unconventional array notation | 1 | 0 |
Redundant declarations | 1 | 0 |
Redundant function pointer dereferencing | 1 | 0 |
Redundant preprocessor | 1 | 0 |
Simple booleans | 1 | 0 |
Simple subscript | 1 | 0 |
Uppercase suffixes | 1 | 0 |