### PR TITLE
[clang-tidy] Vote: Type safety checks

### DIFF
--- a/formatting-tools/.clang-tidy
+++ b/formatting-tools/.clang-tidy
@@ -1,17 +1,30 @@
-Checks: 'bugprone-copy-constructor-init,
+Checks: 'bugprone-bool-pointer-implicit-conversion,
+bugprone-copy-constructor-init,
 bugprone-forwarding-reference-overload,
+bugprone-misplaced-widening-cast,
 bugprone-parent-virtual-call,
+bugprone-signed-char-misuse,
+bugprone-suspicious-enum-usage,
+bugprone-swapped-arguments,
 bugprone-undelegated-constructor,
 bugprone-unhandled-self-assignment,
 bugprone-virtual-near-miss,
+cert-dcl50-cpp,
 cert-oop57-cpp,
 cert-oop58-cpp,
+cppcoreguidelines-narrowing-conversions,
+cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+cppcoreguidelines-pro-type-cstyle-cast,
 cppcoreguidelines-pro-type-member-init,
+cppcoreguidelines-pro-type-static-cast-downcast,
+cppcoreguidelines-pro-type-vararg,
 cppcoreguidelines-slicing,
 cppcoreguidelines-special-member-functions,
 google-default-arguments,
 google-explicit-constructor,
+google-readability-casting,
 google-readability-todo,
+hicpp-signed-bitwise,
 misc-misplaced-const,
 misc-unconventional-assign-operator,
 modernize-raw-string-literal,
@@ -19,20 +32,25 @@ modernize-replace-disallow-copy-and-assign-macro,
 modernize-return-braced-init-list,
 modernize-unary-static-assert,
 modernize-use-auto,
+modernize-use-bool-literals,
 modernize-use-default-member-init,
 modernize-use-equals-default,
 modernize-use-equals-delete,
+modernize-use-nullptr,
 modernize-use-override,
+modernize-use-transparent-functors,
 modernize-use-using,
 readability-avoid-const-params-in-decls,
 readability-const-return-type,
 readability-convert-member-functions-to-static,
 readability-deleted-default,
-readability-non-const-parameter'
 readability-identifier-naming,
+readability-implicit-bool-conversion,
 readability-isolate-declaration,
 readability-make-member-function-const,
 readability-misplaced-array-index,
+readability-non-const-parameter,
+readability-qualified-auto,
 readability-redundant-access-specifiers,
 readability-redundant-declaration,
 readability-redundant-function-ptr-dereference,
@@ -42,20 +60,31 @@ readability-simplify-boolean-expr,
 readability-simplify-subscript-expr,
 readability-static-accessed-through-instance'
 CheckOptions:
+  - { key: bugprone-misplaced-widening-cast.CheckImplicitCasts, value: 1}
+  - { key: bugprone-signed-char-misuse.CharTypedefsToIgnore, value: "int8_t;std::int8_t"}
+  - { key: bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons, value: 1}
+  - { key: bugprone-suspicious-enum-usage.StrictMode, value: 1}
   - { key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField, value: 0}
+  - { key: cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion, value: 1}
+  - { key: cppcoreguidelines-narrowing-conversions.WarnWithinTemplateInstantiation, value: 1}
+  - { key: cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth, value: 1}
+  - { key: cppcoreguidelines-narrowing-conversions.PedanticMode, value: 1}
   - { key: cppcoreguidelines-pro-type-member-init.IgnoreArrays, value: 0}
   - { key: cppcoreguidelines-pro-type-member-init.UseAssignment, value: 0}
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor, value: 0}
   - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions, value: 0}
   - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted, value: 0}
+  - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: false}
   - { key: modernize-use-auto.MinTypeNameLength, value: 0}
   - { key: modernize-use-auto.RemoveStars, value: 0}
+  - { key: modernize-use-bool-literals.IgnoreMacros, value: 0}
   - { key: modernize-use-default-member-init.UseAssignment, value: 0}
   - { key: modernize-use-default-member-init.IgnoreMacros, value: 0}
   - { key: modernize-use-equals-default.IgnoreMacros, value: 0}
   - { key: modernize-use-equals-delete.IgnoreMacros, value: 0}
   - { key: modernize-use-override.IgnoreDestructors, value: 0}
   - { key: modernize-use-override.AllowOverrideAndFinal, value: 1}
+  - { key: modernize-use-transparent-functors.SafeMode, value: 1}
   - { key: modernize-use-using.IgnoreMacros, value: 0}
   - { key: readability-identifier-naming.AbstractClassCase, value: CamelCase}
   - { key: readability-identifier-naming.AggressiveDependentMemberLookup, value: 1}
@@ -117,6 +146,9 @@ CheckOptions:
   - { key: readability-identifier-naming.ValueTemplateParameterPrefix, value: T}
   - { key: readability-identifier-naming.VariableCase, value: lower_case}
   - { key: readability-identifier-naming.VirtualMethodCase, value: lower_case}
+  - { key: readability-implicit-bool-conversion.AllowIntegerConditions, value: 0}
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions, value: 0}
+  - { key: readability-qualified-auto.AddConstToQualified, value: 1}
   - { key: readability-redundant-access-specifiers.CheckFirstDeclaration, value: 1}
   - { key: readability-redundant-declaration.IgnoreMacros, value: 0}
   - { key: readability-redundant-member-init.IgnoreBaseInCopyConstructors, value: 1}


### PR DESCRIPTION
This PR adds type safety checks to our .clang-tidy file.

* No implicit `bool`-to-pointer conversions ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-bool-pointer-implicit-conversion.html))
* No implicit `bool` conversions to any builtin type ([Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-conversion.html))
* Avoid precision loss on widening integer casts ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-widening-cast.html))
* Be extra careful with `signed char` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-signed-char-misuse.html))
* Do not embed `\0` in strings ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-literal-with-embedded-nul.html))
* Do not misuse non-class `enum`s ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-enum-usage.html))
* Detect (accidentally) swapped arguments ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-swapped-arguments.html))
* Do not implement C-style variadic functions ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cert-dcl50-cpp.html))
* Do not use C-style variadic arguments ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-vararg.html))
* No implicit narrowing conversions ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-narrowing-conversions.html))
* No array-to-pointer decays ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-array-to-pointer-decay.html))
* Do not use `const_cast` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-const-cast.html))
* Do not use unsafe C-style casts ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-cstyle-cast.html))
* Do not use any C-style casts ([Link](https://clang.llvm.org/extra/clang-tidy/checks/google-readability-casting.html))
* Do not use `reinterpret_cast` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-reinterpret-cast.html))
* Do not use `static_cast` to cast base classes to derived classes ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-static-cast-downcast.html))
* Do not access `union` members ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-union-access.html))
* Use `std::(u)intXX_t` instead of signed/unsigned `short`, `long` and `long long` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/google-runtime-int.html))
* Do not perform bitwise operations on signed integers ([Link](https://clang.llvm.org/extra/clang-tidy/checks/hicpp-signed-bitwise.html))
* Use `bool` literals instead of `0` and `1` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-bool-literals.html))
* Use `nullptr` instead of `NULL` or `0` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nullptr.html))
* Use transparent functors ([Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-transparent-functors.html))
* Even with `auto`, use `const`, `*` and `&` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-qualified-auto.html))

Voting will close on Friday, 04 June 2021, 18:00 HZDR time.

### Vote

Check | Yes | No | Comment
------|-----|----|--------
No implicit `bool`-to-pointer conversion | 1 | 0 | 
No implicit `bool` conversion to any type | 1 | 0 | 
No precision loss on widening integer casts | 1 | 0 | 
Special care for `signed char` | 1 | 0 | 
No embedded `\0` in strings | 1 | 0 | 
No `enum` misuse | 1 | 0 | 
Detect swapped arguments | 1 | 0 | 
No C-style variadic functions | 1 | 0 | 
No C-style variadic arguments | 1 | 0 | 
No implicit narrowing | 1 | 0 | 
No array-to-pointer decay | 1 | 0 | 
No `const_cast` | 1 | 0 | 
No **unsafe** C-style casts | 1 | 0 | 
No C-style casts **in any form** | 1 | 0 | 
No `reinterpret_cast` | 0 | 1 | 
No `static_cast` for downcasting | 1 | 0 | 
No access to `union` members | 1 | 0 | 
Use fixed-width integer types | 1 | 0 | 
No bitwise operations on signed integers | 1 | 0 | 
Use `bool` literals | 1 | 0 | 
Use `nullptr` | 1 | 0 | 
Use transparent functors | 1 | 0 | 
Use qualified `auto` | 1 | 0 | 

### Vote template

```
Check | Yes | No | Comment
------|-----|----|--------
No implicit `bool`-to-pointer conversion | X | X | 
No implicit `bool` conversion to any type | X | X | 
No precision loss on widening integer casts | X | X | 
Special care for `signed char` | X | X | 
No embedded `\0` in strings | X | X | 
No `enum` misuse | X | X | 
Detect swapped arguments | X | X | 
No C-style variadic functions | X | X | 
No C-style variadic arguments | X | X | 
No implicit narrowing | X | X | 
No array-to-pointer decay | X | X | 
No `const_cast` | X | X | 
No **unsafe** C-style casts | X | X | 
No C-style casts **in any form** | X | X | 
No `reinterpret_cast` | X | X | 
No `static_cast` for downcasting | X | X | 
No access to `union` members | X | X | 
Use fixed-width integer types | X | X | 
No bitwise operations on signed integers | X | X | 
Use `bool` literals | X | X | 
Use `nullptr` | X | X | 
Use transparent functors | X | X | 
Use qualified `auto` | X | X | 
```