### PR TITLE
[clang-tidy] Vote: General safety checks

### DIFF
--- a/formatting-tools/.clang-tidy
+++ b/formatting-tools/.clang-tidy
@@ -1,17 +1,29 @@
-Checks: 'bugprone-bool-pointer-implicit-conversion,
+Checks: 'bugprone-assert-side-effect,
+bugprone-bool-pointer-implicit-conversion,
 bugprone-copy-constructor-init,
+bugprone-dangling-handle,
 bugprone-forwarding-reference-overload,
+bugprone-lambda-function-name,
 bugprone-misplaced-widening-cast,
 bugprone-parent-virtual-call,
 bugprone-signed-char-misuse,
+bugprone-sizeof-expression,
 bugprone-suspicious-enum-usage,
+bugprone-suspicious-include,
+bugprone-suspicious-missing-comma,
 bugprone-swapped-arguments,
+bugprone-undefined-memory-manipulation,
 bugprone-undelegated-constructor,
 bugprone-unhandled-self-assignment,
+bugprone-unused-return-value,
+bugprone-use-after-move,
 bugprone-virtual-near-miss,
 cert-dcl50-cpp,
+cert-mem57-cpp,
 cert-oop57-cpp,
 cert-oop58-cpp,
+cppcoreguidelines-init-variables,
+cppcoreguidelines-interfaces-global-init,
 cppcoreguidelines-narrowing-conversions,
 cppcoreguidelines-pro-bounds-array-to-pointer-decay,
 cppcoreguidelines-pro-type-cstyle-cast,
@@ -24,8 +36,14 @@ google-default-arguments,
 google-explicit-constructor,
 google-readability-casting,
 google-readability-todo,
+google-runtime-operator,
 hicpp-signed-bitwise,
+misc-definitions-in-headers,
 misc-misplaced-const,
+misc-new-delete-overloads,
+misc-non-copyable-objects,
+misc-redundant-expression,
+misc-static-assert,
 misc-unconventional-assign-operator,
 modernize-raw-string-literal,
 modernize-replace-disallow-copy-and-assign-macro,
@@ -60,11 +78,26 @@ readability-simplify-boolean-expr,
 readability-simplify-subscript-expr,
 readability-static-accessed-through-instance'
 CheckOptions:
+  - { key: bugprone-assert-side-effect.AssertMacros, value: [assert]}
+  - { key: bugprone-assert-side-effect.CheckFunctionCalls, value: 0}
+  - { key: bugprone-dangling-handle.HandleClasses, value: "std::basic_string_view;std::experimental::basic_string_view"}
   - { key: bugprone-misplaced-widening-cast.CheckImplicitCasts, value: 1}
   - { key: bugprone-signed-char-misuse.CharTypedefsToIgnore, value: "int8_t;std::int8_t"}
   - { key: bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons, value: 1}
+  - { key: bugprone-sizeof-expression.WarnOnSizeOfConstant, value: 1}
+  - { key: bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression, value: 1}
+  - { key: bugprone-sizeof-expression.WarnOnSizeOfThis, value: 1}
+  - { key: bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant, value: 1}
   - { key: bugprone-suspicious-enum-usage.StrictMode, value: 1}
+  - { key: bugprone-suspicious-include.HeaderFileExtensions, value: ";h;hh;hpp;hxx;cuh"}
+  - { key: bugprone-suspicious-include.ImplementationFileExtensions, value: "c;cc;cpp;cxx;cu"}
+  - { key: bugprone-suspicious-missing-comma.SizeThreshold, value: "5U"}
+  - { key: bugprone-suspicious-missing-comma.RatioThreshold, value: ".2"}
+  - { key: bugprone-suspicious-missing-comma.MaxConcatenatedTokens, value: "5U"}
   - { key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField, value: 0}
+  - { key: bugprone-unused-return-value.CheckedFunctions, value: "::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty"}
+  - { key: cppcoreguidelines-init-variables.IncludeStyle, value: "llvm"}
+  - { key: cppcoreguidelines-init-variables.MathHeader, value: "<cmath>" }
   - { key: cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion, value: 1}
   - { key: cppcoreguidelines-narrowing-conversions.WarnWithinTemplateInstantiation, value: 1}
   - { key: cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth, value: 1}
@@ -75,6 +108,8 @@ CheckOptions:
   - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions, value: 0}
   - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted, value: 0}
   - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: false}
+  - { key: misc-definitions-in-headers.HeaderFileExtensions, value: "h,hh,hpp,hxx"}
+  - { key: misc-definitions-in-header.UseHeaderFileExtension, value: 1}
   - { key: modernize-use-auto.MinTypeNameLength, value: 0}
   - { key: modernize-use-auto.RemoveStars, value: 0}
   - { key: modernize-use-bool-literals.IgnoreMacros, value: 0}
@@ -154,3 +189,4 @@ CheckOptions:
   - { key: readability-redundant-member-init.IgnoreBaseInCopyConstructors, value: 1}
   - { key: readability-simplify-boolean-expr.ChainedConditionalAssignment, value: 1}
   - { key: readability-simplify-boolean-expr.ChainedConditionalReturn, value: 1}
+  


### PR DESCRIPTION
This PR adds general safety checks to our .clang-tidy file.

* No `assert` with side effects ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-assert-side-effect.html))
* Detect dangling references ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-dangling-handle.html)) -- This is probably project-specific
* Don't attempt to access `__func__` / `__FUNCTION__` inside a lambda ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-lambda-function-name.html))
* Find suspicious `sizeof` expressions ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-sizeof-expression.html))
* Find non-header `#include`s ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-include.html)) -- Probably project-specific (for example for allowing `*.ipp` files)
* Warn on probably unwanted string concatenations ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-missing-comma.html))
* Don't use `memset`, `memcpy` and `memmove` on non trivially copyable objects ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-undefined-memory-manipulation.html))
* Don't discard the return value of specific functions ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-unused-return-value.html)) -- Probably project-specific
* Don't use an object after `move` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-use-after-move.html))
* Don't use `new` with custom memory alignment unless you provide a suitable overload / placement `new` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cert-mem57-cpp.html))
* No non-`const` global variables ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-avoid-non-const-global-variables.html))
* No uninitialized local variables ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-init-variables.html))
* Avoid complex initialization of global objects ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-interfaces-global-init.html))
* Use `gsl::owner<T*>` to assign ownership of raw memory ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-owning-memory.html))
* Don't use non-`const` integer expressions as array indices ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-constant-array-index.html))
* Don't do pointer arithmetic ([Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-pointer-arithmetic.html))
* Don't overload operators other than the assignment operator ([Link](https://clang.llvm.org/extra/clang-tidy/checks/fuchsia-overloaded-operator.html))
* Don't create global non-trivial objects with `static` storage ([Link](https://clang.llvm.org/extra/clang-tidy/checks/fuchsia-statically-constructed-objects.html))
* Don't overload the unary operator `&` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/google-runtime-operator.html))
* Don't use assembly statements ([Link](https://clang.llvm.org/extra/clang-tidy/checks/hicpp-no-assembler.html))
* Don't use non-`extern` non-`inline` function and variable definitions in header files ([Link](https://clang.llvm.org/extra/clang-tidy/checks/misc-definitions-in-headers.html))
* Don't overload `new` without a corresponding `delete` (and vice versa) ([Link](https://clang.llvm.org/extra/clang-tidy/checks/misc-new-delete-overloads.html))
* Don't dereference / copy-by-value `FILE*` and `pthread_mutex_t` objects ([Link](https://clang.llvm.org/extra/clang-tidy/checks/misc-non-copyable-objects.html))
* Find redundant expressions ([Link](https://clang.llvm.org/extra/clang-tidy/checks/misc-redundant-expression.html))
* Wherever possible, prefer `static_assert` over `assert` ([Link](https://clang.llvm.org/extra/clang-tidy/checks/misc-static-assert.html))

Voting will close on Friday, 11 June 2021, 18:00 HZDR time.

### Vote template

```
Check | Yes | No | Comment
------|-----|----|--------
No `assert` with side effects | X | X | X
Detect dangling references | X | X | X
Don't access function name inside lambda | X | X | X
Find suspicious `sizeof` | X | X | X
Find non-header `#include`s | X | X | X
No accidental string concats | X | X | X
No `memset` et al. for non-trivial objects | X | X | X
Don't discard return value of specific functions | X | X | X
Don't use after `move` | X | X | X
No standard `new` for custom memory alignment | X | X | X
No non-`const` global vars | X | X | X
No uninitialized local vars | X | X | X
No complex initialization for global objects | X | X | X
Use `gsl::owner<T*>` for raw memory | X | X | X
No non-`const` array indices | X | X | X
No pointer arithmetic | X | X | X
No overloaded operators other than `=` | X | X | X
No non-trivial objects with `static` storage duration | X | X | X
Don't overload unary `&` | X | X | X
No assembly statements | X | X | X
No non-`extern` non-`inline` function / variable definitions in header files | X | X | X
No overloaded `new` without overloaded `delete` | X | X | X
Don't dereference / copy-by-value `FILE*` and `pthread_mutex_t` | X | X | X
Find redundant expressions | X | X | X
Prefer `static_assert` over `assert` | X | X | X
```

### Vote

Check | Yes | No | Comment
------|-----|----|--------
No `assert` with side effects | 1 | 0 | 
Detect dangling references | 1 | 0 | 
Don't access function name inside lambda | 1 | 0 | 
Find suspicious `sizeof` | 1 | 0 | 
Find non-header `#include`s | 1 | 0 | 
No accidental string concats | 1 | 0 | 
No `memset` et al. for non-trivial objects | 1 | 0 | 
Don't discard return value of specific functions | 0 | 1 | We have `[[nodiscard]]` in C++17
Don't use after `move` | 1 | 0 | 
No standard `new` for custom memory alignment | 1 | 0 | 
No non-`const` global vars | 0 | 1 | Not entirely certain here, leaning towards `no`
No uninitialized local vars | 1 | 0 | 
No complex initialization for global objects | 1 | 0 |
Use `gsl::owner<T*>` for raw memory | 0 | 1 |
No non-`const` array indices | 0 | 1 |
No pointer arithmetic | 0 | 1 |
No overloaded operators other than `=` | 0 | 1 | Leaning towards `no` but might be persuaded otherwise
No non-trivial objects with `static` storage duration | 0 | 1 |
Don't overload unary `&` | 1 | 0 |
No assembly statements | 1 | 0 |
No non-`extern` non-`inline` function / variable definitions in header files | 1 | 0 |
No overloaded `new` without overloaded `delete` | 1 | 0 | 
Don't dereference / copy-by-value `FILE*` and `pthread_mutex_t` | 1 | 0 |
Find redundant expressions | 1 | 0 |
Prefer `static_assert` over `assert` | 1 | 0 |