### PR TITLE
Avoid prefixing public data members

### DIFF
--- a/formatting-tools/.clang-tidy
+++ b/formatting-tools/.clang-tidy
@@ -115,7 +115,6 @@ CheckOptions:
   - { key: readability-identifier-naming.LocalVariableCase, value: lower_case}
   - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE}
   - { key: readability-identifier-naming.MemberCase, value: lower_case}
-  - { key: readability-identifier-naming.MemberPrefix, value: m_}
   - { key: readability-identifier-naming.MethodCase, value: lower_case}
   - { key: readability-identifier-naming.NamespaceCase, value: lower_case}
   - { key: readability-identifier-naming.ParameterCase, value: lower_case}
@@ -128,7 +127,6 @@ CheckOptions:
   - { key: readability-identifier-naming.ProtectedMemberPrefix, value: m_}
   - { key: readability-identifier-naming.ProtectedMethodCase, value: lower_case}
   - { key: readability-identifier-naming.PublicMemberCase, value: lower_case}
-  - { key: readability-identifier-naming.PublicMemberPrefix, value: m_}
   - { key: readability-identifier-naming.PublicMethodCase, value: lower_case}
   - { key: readability-identifier-naming.StaticConstantCase, value: lower_case}
   - { key: readability-identifier-naming.StaticVariableCase, value: lower_case}


### PR DESCRIPTION
As discussed in the alpaka VC today, this PR changes the `.clang-tidy` file to not rewrite public non-static data members of classes to include an `m_` prefix.