### PR TITLE
Ignore prefixing template parameters with 1 or 2 letters

### DIFF
--- a/formatting-tools/.clang-tidy
+++ b/formatting-tools/.clang-tidy
@@ -135,15 +135,19 @@ CheckOptions:
   - { key: readability-identifier-naming.StructCase, value: CamelCase}
   - { key: readability-identifier-naming.TemplateParameterCase, value: CamelCase}
   - { key: readability-identifier-naming.TemplateParameterPrefix, value: T}
+  - { key: readability-identifier-naming.TemplateParameterIgnoredRegexp, value: "..?"}
   - { key: readability-identifier-naming.TemplateTemplateParameterCase, value: CamelCase}
   - { key: readability-identifier-naming.TemplateTemplateParameterPrefix, value: T}
+  - { key: readability-identifier-naming.TemplateTemplateParameterIgnoredRegexp, value: "..?"}
   - { key: readability-identifier-naming.TypeAliasCase, value: CamelCase}
   - { key: readability-identifier-naming.TypedefCase, value: CamelCase}
   - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase}
   - { key: readability-identifier-naming.TypeTemplateParameterPrefix, value: T}
+  - { key: readability-identifier-naming.TypeTemplateParameterIgnoredRegexp, value: "..?"}
   - { key: readability-identifier-naming.UnionCase, value: CamelCase}
   - { key: readability-identifier-naming.ValueTemplateParameterCase, value: CamelCase}
   - { key: readability-identifier-naming.ValueTemplateParameterPrefix, value: T}
+  - { key: readability-identifier-naming.ValueTemplateParameterIgnoredRegexp, value: "..?"}
   - { key: readability-identifier-naming.VariableCase, value: lower_case}
   - { key: readability-identifier-naming.VirtualMethodCase, value: lower_case}
   - { key: readability-implicit-bool-conversion.AllowIntegerConditions, value: 0}


### PR DESCRIPTION
As discussed in the alpaka VC today, this PR changes the `.clang-tidy` file to not prefix template parameters with 1 or 2 letters with `T`.