### PR TITLE
[clang-tidy] Vote: Control flow checks

### DIFF
--- a/formatting-tools/.clang-tidy
+++ b/formatting-tools/.clang-tidy
@@ -1,20 +1,27 @@
 Checks: 'bugprone-assert-side-effect,
 bugprone-bool-pointer-implicit-conversion,
+bugprone-branch-clone,
 bugprone-copy-constructor-init,
 bugprone-dangling-handle,
 bugprone-forwarding-reference-overload,
+bugprone-infinite-loop,
 bugprone-lambda-function-name,
 bugprone-misplaced-widening-cast,
 bugprone-parent-virtual-call,
+bugprone-redundant-branch-condition,
 bugprone-signed-char-misuse,
 bugprone-sizeof-expression,
 bugprone-suspicious-enum-usage,
 bugprone-suspicious-include,
 bugprone-suspicious-missing-comma,
+bugprone-suspicious-semicolon,
 bugprone-swapped-arguments,
+bugprone-terminating-continue,
+bugprone-too-small-loop-variable,
 bugprone-undefined-memory-manipulation,
 bugprone-undelegated-constructor,
 bugprone-unhandled-self-assignment,
+bugprone-unused-raii,
 bugprone-unused-return-value,
 bugprone-use-after-move,
 bugprone-virtual-near-miss,
@@ -22,6 +29,7 @@ cert-dcl50-cpp,
 cert-mem57-cpp,
 cert-oop57-cpp,
 cert-oop58-cpp,
+cppcoreguidelines-avoid-goto,
 cppcoreguidelines-init-variables,
 cppcoreguidelines-interfaces-global-init,
 cppcoreguidelines-narrowing-conversions,
@@ -37,6 +45,7 @@ google-explicit-constructor,
 google-readability-casting,
 google-readability-todo,
 google-runtime-operator,
+hicpp-multiway-paths-covered,
 hicpp-signed-bitwise,
 misc-definitions-in-headers,
 misc-misplaced-const,
@@ -61,15 +70,19 @@ modernize-use-using,
 readability-avoid-const-params-in-decls,
 readability-const-return-type,
 readability-convert-member-functions-to-static,
+readability-delete-null-pointer,
 readability-deleted-default,
+readability-else-after-return,
 readability-identifier-naming,
 readability-implicit-bool-conversion,
 readability-isolate-declaration,
 readability-make-member-function-const,
+readability-misleading-indentation,
 readability-misplaced-array-index,
 readability-non-const-parameter,
 readability-qualified-auto,
 readability-redundant-access-specifiers,
+readability-redundant-control-flow,
 readability-redundant-declaration,
 readability-redundant-function-ptr-dereference,
 readability-redundant-member-init,
@@ -94,6 +107,7 @@ CheckOptions:
   - { key: bugprone-suspicious-missing-comma.SizeThreshold, value: 5}
   - { key: bugprone-suspicious-missing-comma.RatioThreshold, value: ".2"}
   - { key: bugprone-suspicious-missing-comma.MaxConcatenatedTokens, value: 5}
+  - { key: bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit, value: 31}
   - { key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField, value: 0}
   - { key: bugprone-unused-return-value.CheckedFunctions, value: "::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty"}
   - { key: cppcoreguidelines-init-variables.IncludeStyle, value: "llvm"}
@@ -107,6 +121,7 @@ CheckOptions:
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor, value: 0}
   - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions, value: 0}
   - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted, value: 0}
+  - { key: hicpp-multiway-paths-covered.WarnOnMissingElse, value: 1}
   - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: false}
   - { key: misc-definitions-in-headers.HeaderFileExtensions, value: "h,hh,hpp,hxx"}
   - { key: misc-definitions-in-header.UseHeaderFileExtension, value: 1}
@@ -121,6 +136,8 @@ CheckOptions:
   - { key: modernize-use-override.AllowOverrideAndFinal, value: 1}
   - { key: modernize-use-transparent-functors.SafeMode, value: 1}
   - { key: modernize-use-using.IgnoreMacros, value: 0}
+  - { key: readability-else-after-return.WarnOnUnfixable, value: 1}
+  - { key: readability-else-after-return.WarnOnConditionVariables, value: 1}
   - { key: readability-identifier-naming.AbstractClassCase, value: CamelCase}
   - { key: readability-identifier-naming.AggressiveDependentMemberLookup, value: 1}
   - { key: readability-identifier-naming.ClassCase, value: CamelCase}


### PR DESCRIPTION
This PR adds control flow checks to our `.clang-tidy` file.

Note: I intentionally left out the `modernize-loop-convert` check ([Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html)) because it has compatibility issues with OpenMP.

**Voting will close on 02 July 2021, 18:00 HZDR time.**

* Do not repeat branches - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-branch-clone.html)
* Find obvious infinite loops - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-infinite-loop.html)
* Find redundant branch conditions - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-redundant-branch-condition.html)
* Find suspicious semicolons - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-semicolon.html)
* Find terminating `continue` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-terminating-continue.html)
* Detect too small loop variables - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-too-small-loop-variable.html). **Note**: Currently this checks for 32-bit integers that are too small. If you want this changed (to 16 bit, for example), please note this in the comment field.
* Find temporaries that look like RAII objects - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-unused-raii.html)
* Do not use floating point types as loop counters - [Link](https://clang.llvm.org/extra/clang-tidy/checks/cert-flp30-c.html)
* Avoid `goto` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-avoid-goto.html)
* Find missing code paths - [Link](https://clang.llvm.org/extra/clang-tidy/checks/hicpp-multiway-paths-covered.html). **Note**: In the current version the check will warn on missing `else` branches if there are `if`-`else if` branches before. If you want this turned off, please note this in the comment field.
* No runtime recursion - [Link](https://clang.llvm.org/extra/clang-tidy/checks/misc-no-recursion.html)
* Put braces around statements - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html). **Note**: Currently the check allows for short statements (== 1 line) to exist without braces. If you want this changed, please note this in the comment field.
* Do not check for `nullptr` when calling `delete` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-delete-null-pointer.html)
* Do not use `else` after `return` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-else-after-return.html)
* Find misleading indentation - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-misleading-indentation.html)
* Find redundant control flow statements - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-control-flow.html)

### Vote template

```markdown
Check | Yes | No | Comment
------|-----|----|--------
Don't repeat branches | X | X | X
Find infinite loops | X | X | X
Find redundant branch conditions | X | X | X
Find suspicious semicolons | X | X | X
Find terminating `continue` | X | X | X
Detect too small loop variables | X | X | X
Find temporaries that look like RAII objects | X | X | X
No floating point loop counters | X | X | X
Avoid `goto` | X | X | X
Find missing code paths | X | X | X
No runtime recursion | X | X | X
Put braces around statements | X | X | X
No `nullptr` check when `delete`ing | X | X | X
No `else` after `return` | X | X | X
Find misleading indentation | X | X | X
Find redundant control flow statements | X | X | X
```

### Vote

Check | Yes | No | Comment
------|-----|----|--------
Don't repeat branches | 1 | 0 | -
Find infinite loops | 1 | 0 | -
Find redundant branch conditions | 1 | 0 | -
Find suspicious semicolons | 1 | 0 | -
Find terminating `continue` | 1 | 0 | -
Detect too small loop variables | 1 | 0 | -
Find temporaries that look like RAII objects | 1 | 0 | -
No floating point loop counters | 1 | 0 | -
Avoid `goto` | 1 | 0 | -
Find missing code paths | 1 | 0 | -
No runtime recursion | 1 | 0 | -
Put braces around statements | 1 | 0 | -
No `nullptr` check when `delete`ing | 1 | 0 | -
No `else` after `return` | 1 | 0 | -
Find misleading indentation | 1 | 0 | -
Find redundant control flow statements | 1 | 0 | -