### PR TITLE
[clang-format] Vote: Update to clang-format 12.

### DIFF
--- a/formatting-tools/.clang-format
+++ b/formatting-tools/.clang-format
@@ -28,8 +28,10 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
+BitFieldColonSpacing: Both
 BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Allman
+BreakBeforeConceptDeclarations: true
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: BeforeComma
@@ -53,6 +55,8 @@ IndentCaseLabels: false
 IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: AfterHash
+IndentPragmas: true
+IndentRequires: true
 IndentWidth: 4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
@@ -76,6 +80,7 @@ SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
@@ -106,9 +111,9 @@ UseTab: Never
 #  - Regex:           '.*'
 #    Priority:        1
 #    SortPriority:    0
+#StatementAttributeLikeMacros: []
 
-# Future options - not supported in clang-format 11
-# BitFieldColonSpacing: Both
+# Future options - not supported in clang-format 12
+# 
 # OperandAlignmentStyle: Align
-
 ...


### PR DESCRIPTION
LLVM 12 has been released a while ago. This PR updates our `.clang-format` file to incorporate the new checks part of this version. This fixes #49. See the detailed descriptions [here](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html).

**Voting will close on 02 July 2021, 18:00 HZDR time.**

### `BitFieldColonSpacing`:

```c++
// Both
struct F {
  unsigned dscp : 6;
  unsigned ecn : 2;
};

// None
struct F {
  unsigned dscp:6;
  unsigned ecn:2;
};

// Before
struct F {
  unsigned dscp :6;
  unsigned ecn :2;
};

// After
struct F {
  unsigned dscp: 6;
  unsigned ecn: 2;
};
```

### `BreakBeforeConceptDeclarations`:

```c++
// true
template<typename T>
concept ...

// false
template<typename T> concept ...
```

### `IndentPragmas`:
```c++
// true
#pragma omp parallel
{
    #pragma omp for
    for (int j = 0; j < 5; j++)
    {
        /* ... */
    }
}
// false
#pragma omp parallel
{
#pragma omp for
    for (int j = 0; j < 5; j++)
    {
        /* ... */
    }
}
```

### `IndentRequires`:
```c++
// true
template <typename It>
  requires Iterator<It>
void sort(It begin, It end) {
  //....
}

// false
template <typename It>
requires Iterator<It>
void sort(It begin, It end) {
  //....
}
```

### `SpaceBeforeCaseColon`:
```c++
switch(x)
{
    // true
    case 1 : 
        break;

    // false
    case 2:
        break;
}
```

### `StatementAttributeLikeMacros`:

This is a project-specific option. It allows to define macros which are treated like attributes (like `[[gnu::always_inline]]`). Example:

```c++
// StatementAttributeLikeMacros: []
MyAttributeMacro specialVar;
// StatementAttributeLikeMacros: [MyAttributeMacro]
MyAttributeMacro        specialVar; // Indentation not touched by clang-format
```

## Vote template

```markdown
BitFieldColonSpacing | Both | None | Before | After | Comment
---------------------|------|------|--------|-------|--------
dummy | X | X | X | X | X

Check | true | false | Comment
------|------|-------|--------
BreakBeforeConceptDeclarations | X | X | X
IndentPragmas | X | X | X
IndentRequires | X | X | X
SpaceBeforeCaseColon | X | X | X
```

## Vote

BitFieldColonSpacing | Both | None | Before | After | Comment
---------------------|------|------|--------|-------|--------
dummy | 1 | 0 | 0 | 0 | -

Check | true | false | Comment
------|------|-------|--------
BreakBeforeConceptDeclarations | 1 | 0 | -
IndentPragmas | 1 | 0 | -
IndentRequires | 1 | 0 | -
SpaceBeforeCaseColon | 0 | 1 | -