### PR TITLE
Add stdlib checks

### DIFF
--- a/formatting-tools/.clang-tidy
+++ b/formatting-tools/.clang-tidy
@@ -1,20 +1,32 @@
-Checks: 'bugprone-assert-side-effect,
+Checks: 'boost-use-to-string,
+bugprone-assert-side-effect,
 bugprone-bool-pointer-implicit-conversion,
 bugprone-branch-clone,
 bugprone-copy-constructor-init,
 bugprone-dangling-handle,
 bugprone-forwarding-reference-overload,
+bugprone-inaccurate-erase,
 bugprone-infinite-loop,
 bugprone-lambda-function-name,
+bugprone-misplaced-operator-in-strlen-in-alloc,
+bugprone-misplaced-pointer-arithmetic-in-alloc,
 bugprone-misplaced-widening-cast,
+bugprone-move-forwarding-reference,
+bugprone-not-null-terminated-result,
 bugprone-parent-virtual-call,
 bugprone-redundant-branch-condition,
+bugprone-reserved-identifier,
 bugprone-signed-char-misuse,
+bugprone-sizeof-container,
 bugprone-sizeof-expression,
+bugprone-string-constructor,
+bugprone-string-integer-assignment,
 bugprone-suspicious-enum-usage,
 bugprone-suspicious-include,
+bugprone-suspicious-memset-usage,
 bugprone-suspicious-missing-comma,
 bugprone-suspicious-semicolon,
+bugprone-suspicious-string-compare,
 bugprone-swapped-arguments,
 bugprone-terminating-continue,
 bugprone-too-small-loop-variable,
@@ -26,6 +38,9 @@ bugprone-unused-return-value,
 bugprone-use-after-move,
 bugprone-virtual-near-miss,
 cert-dcl50-cpp,
+cert-dcl58-cpp,
+cert-err34-c,
+cert-err52-cpp,
 cert-mem57-cpp,
 cert-oop57-cpp,
 cert-oop58-cpp,
@@ -33,6 +48,7 @@ cppcoreguidelines-avoid-goto,
 cppcoreguidelines-init-variables,
 cppcoreguidelines-interfaces-global-init,
 cppcoreguidelines-narrowing-conversions,
+cppcoreguidelines-no-malloc,
 cppcoreguidelines-pro-bounds-array-to-pointer-decay,
 cppcoreguidelines-pro-type-cstyle-cast,
 cppcoreguidelines-pro-type-member-init,
@@ -40,6 +56,7 @@ cppcoreguidelines-pro-type-static-cast-downcast,
 cppcoreguidelines-pro-type-vararg,
 cppcoreguidelines-slicing,
 cppcoreguidelines-special-member-functions,
+google-build-explicit-make-pair,
 google-default-arguments,
 google-explicit-constructor,
 google-readability-casting,
@@ -54,13 +71,24 @@ misc-non-copyable-objects,
 misc-redundant-expression,
 misc-static-assert,
 misc-unconventional-assign-operator,
+misc-uniqueptr-reset-release,
+modernize-avoid-bind,
+modernize-avoid-c-arrays,
+modernize-deprecated-headers,
+modernize-deprecated-ios-base-aliases,
+modernize-make-shared,
+modernize-make-unique,
 modernize-raw-string-literal,
+modernize-replace-auto-ptr,
 modernize-replace-disallow-copy-and-assign-macro,
+modernize-replace-random-shuffle,
+modernize-replace-shrink-to-fit,
 modernize-return-braced-init-list,
 modernize-unary-static-assert,
 modernize-use-auto,
 modernize-use-bool-literals,
 modernize-use-default-member-init,
+modernize-use-emplace,
 modernize-use-equals-default,
 modernize-use-equals-delete,
 modernize-use-nullptr,
@@ -69,6 +97,7 @@ modernize-use-transparent-functors,
 modernize-use-using,
 readability-avoid-const-params-in-decls,
 readability-const-return-type,
+readability-container-size-empty,
 readability-convert-member-functions-to-static,
 readability-delete-null-pointer,
 readability-deleted-default,
@@ -87,26 +116,41 @@ readability-redundant-declaration,
 readability-redundant-function-ptr-dereference,
 readability-redundant-member-init,
 readability-redundant-preprocessor,
+readability-redundant-smartptr-get,
+readability-redundant-string-cstr,
+readability-redundant-string-init,
 readability-simplify-boolean-expr,
 readability-simplify-subscript-expr,
-readability-static-accessed-through-instance'
+readability-static-accessed-through-instance,
+readability-string-compare,
+readability-uniqueptr-delete-release,
+readability-use-anyofallof'
 CheckOptions:
   - { key: bugprone-assert-side-effect.AssertMacros, value: "assert"}
   - { key: bugprone-assert-side-effect.CheckFunctionCalls, value: 0}
   - { key: bugprone-dangling-handle.HandleClasses, value: "std::basic_string_view;std::experimental::basic_string_view"}
   - { key: bugprone-misplaced-widening-cast.CheckImplicitCasts, value: 1}
+  - { key: bugprone-not-null-terminated-result.WantToUseSafeFunctions, value: 1}
+  - { key: bugprone-reserved-identifier.Invert, value: 0}
+  - { key: bugprone-reserved-identifier.AllowedIdentifiers, value: ""}
   - { key: bugprone-signed-char-misuse.CharTypedefsToIgnore, value: "int8_t;std::int8_t"}
   - { key: bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons, value: 1}
   - { key: bugprone-sizeof-expression.WarnOnSizeOfConstant, value: 1}
   - { key: bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression, value: 1}
   - { key: bugprone-sizeof-expression.WarnOnSizeOfThis, value: 1}
   - { key: bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant, value: 1}
+  - { key: bugprone-string-constructor.WarnOnLargeLength, value: 1}
+  - { key: bugprone-string-constructor.LargeLengthThreshold, value: "0x800000"}
+  - { key: bugprone-string-constructor.StringNames, value: "::std::basic_string;::std::basic_string_view"}
   - { key: bugprone-suspicious-enum-usage.StrictMode, value: 1}
   - { key: bugprone-suspicious-include.HeaderFileExtensions, value: ";h;hh;hpp;hxx;cuh"}
   - { key: bugprone-suspicious-include.ImplementationFileExtensions, value: "c;cc;cpp;cxx;cu"}
   - { key: bugprone-suspicious-missing-comma.SizeThreshold, value: 5}
   - { key: bugprone-suspicious-missing-comma.RatioThreshold, value: ".2"}
   - { key: bugprone-suspicious-missing-comma.MaxConcatenatedTokens, value: 5}
+  - { key: bugprone-suspicious-string-compare.WarnOnImplicitComparison, value: 1}
+  - { key: bugprone-suspicious-string-compare.WarnOnLogicalNotComparison, value: 0}
+  - { key: bugprone-suspicious-string-compare.StringCompareLikeFunctions, value: ""}
   - { key: bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit, value: 31}
   - { key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField, value: 0}
   - { key: bugprone-unused-return-value.CheckedFunctions, value: "::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty"}
@@ -116,6 +160,9 @@ CheckOptions:
   - { key: cppcoreguidelines-narrowing-conversions.WarnWithinTemplateInstantiation, value: 1}
   - { key: cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth, value: 1}
   - { key: cppcoreguidelines-narrowing-conversions.PedanticMode, value: 1}
+  - { key: cppcoreguidelines-no-malloc.Allocations, value: "::malloc;::calloc"}
+  - { key: cppcoreguidelines-no-malloc.Deallocations, value: "::free"}
+  - { key: cppcoreguidelines-no-malloc.Reallocations, value: "::realloc"}
   - { key: cppcoreguidelines-pro-type-member-init.IgnoreArrays, value: 0}
   - { key: cppcoreguidelines-pro-type-member-init.UseAssignment, value: 0}
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor, value: 0}
@@ -125,11 +172,29 @@ CheckOptions:
   - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: false}
   - { key: misc-definitions-in-headers.HeaderFileExtensions, value: "h,hh,hpp,hxx"}
   - { key: misc-definitions-in-header.UseHeaderFileExtension, value: 1}
+  - { key: misc-unique-ptr-reset-release.IncludeStyle, value: "llvm"}
+  - { key: modernize-avoid-bind.PermissiveParameterList, value: 1}
+  - { key: modernize-make-shared.MakeSmartPtrFunction, value: "std::make_shared"}
+  - { key: modernize-make-shared.MakeSmartPtrFunctionHeader, value: "memory"}
+  - { key: modernize-make-shared.IncludeStyle, value: "llvm"}
+  - { key: modernize-make-shared.IgnoreMacros, value: 0}
+  - { key: modernize-make-shared.IgnoreDefaultInitialization, value: 1}
+  - { key: modernize-make-unique.MakeSmartPtrFunction, value: "std::make_unique"}
+  - { key: modernize-make-unique.MakeSmartPtrFunctionHeader, value: "memory"}
+  - { key: modernize-make-unique.IncludeStyle, value: "llvm"}
+  - { key: modernize-make-unique.IgnoreMacros, value: 0}
+  - { key: modernize-make-unique.IgnoreDefaultInitialization, value: 1}
+  - { key: modernize-replace-auto-ptr.IncludeStyle, value: "llvm"}
   - { key: modernize-use-auto.MinTypeNameLength, value: 0}
   - { key: modernize-use-auto.RemoveStars, value: 0}
   - { key: modernize-use-bool-literals.IgnoreMacros, value: 0}
   - { key: modernize-use-default-member-init.UseAssignment, value: 0}
   - { key: modernize-use-default-member-init.IgnoreMacros, value: 0}
+  - { key: modernize-use-emplace.ContainersWithPushBack, value: "::std::deque;::std::list;::std::vector"}
+  - { key: modernize-use-emplace.IgnoreImplicitConstructors, value: 0}
+  - { key: modernize-use-emplace.SmartPointers, value: "::std::auto_ptr;::std::shared_ptr;::std::unique_ptr"}
+  - { key: modernize-use-emplace.TupleTypes, value: "::std::pair;::std::tuple"}
+  - { key: modernize-use-emplace.TupleMakeFunctions, value: "::std::make_pair;::std::make_tuple"}
   - { key: modernize-use-equals-default.IgnoreMacros, value: 0}
   - { key: modernize-use-equals-delete.IgnoreMacros, value: 0}
   - { key: modernize-use-override.IgnoreDestructors, value: 0}
@@ -206,6 +271,8 @@ CheckOptions:
   - { key: readability-redundant-access-specifiers.CheckFirstDeclaration, value: 1}
   - { key: readability-redundant-declaration.IgnoreMacros, value: 0}
   - { key: readability-redundant-member-init.IgnoreBaseInCopyConstructors, value: 1}
+  - { key: readability-redundant-smartptr-get.IgnoreMacros, value: 0}
+  - { key: readability-redundant-string-init.StringNames, value: "::std::basic_string;::std::basic_string_view"}
   - { key: readability-simplify-boolean-expr.ChainedConditionalAssignment, value: 1}
   - { key: readability-simplify-boolean-expr.ChainedConditionalReturn, value: 1}
-  
+  - { key: readability-uniqueptr-delete-release.PreferResetCall, value: 0}


### PR DESCRIPTION
This PR adds checks for using the C and C++ standard libraries to our .clang-tidy file.

Voting will close on 20 August 2021, 18:00 HZDR time.

* Use `std::to_string` instead of `boost::lexical_cast` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/boost-use-to-string.html)
* Check for inaccurate use of `erase()` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-inaccurate-erase.html)
* Check for incorrect use of `strlen` in allocation functions - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-operator-in-strlen-in-alloc.html)
* Check for misplaced pointer arithmetic in allocation functions - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-pointer-arithmetic-in-alloc.html) 
* Don't use `move` where you should use `forward` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-move-forwarding-reference.html)
* Find memory operations on `char*` that may cause non-null terminated results - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-not-null-terminated-result.html) - Also note the option
* Don't use identifiers reserved for the C++ implementation - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-reserved-identifier.html) - Also note the options
* Don't use `sizeof` to determine container size - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-sizeof-container.html)
* Find suspicious constructions of `std::string` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-constructor.html) - Also note the options
* Find suspicious integer-to-`std::string` assignments - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-integer-assignment.html)
* Find suspicious usages of `std::memset` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-memset-usage.html)
* Find suspicious usages of `std::strcmp` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-string-compare.html) - Also note the options
* Don't add stuff to `namespace std` and `namespace posix` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/cert-dcl58-cpp.html)
* Don't use non-verifying string-to-number conversions - [Link](https://clang.llvm.org/extra/clang-tidy/checks/cert-err34-c.html)
* Don't use `setjmp` and `longjmp` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/cert-err52-cpp.html)
* Don't use `malloc` and its siblings - [Link](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-no-malloc.html) - Also note the options
* Don't use explicit template parameters with `std::make_pair` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/google-build-explicit-make-pair.html)
* Replace `std::unique_ptr::reset(release())` with `std::move` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/misc-uniqueptr-reset-release.html) - Also note the option
* Use lambdas instead of `std::bind` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-avoid-bind.html) - Also note the option
* Use `std::array` / `std::vector` instead of C arrays - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-avoid-c-arrays.html)
* Flag deprecated headers - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html)
* Flag deprecated aliases from `std::ios_base` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-ios-base-aliases.html)
* Replace `std::shared_ptr{new T}` with `std::make_shared` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-make-shared.html) - Also note the options
* Replace `std::unique_ptr{new T}` with `std::make_unique` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-make-unique.html) - Also note the options
* Replace `std::auto_ptr` with `std::unique_ptr` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-replace-auto-ptr.html) - Also note the option
* Replace `std::random_shuffle` with `std::shuffle` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-replace-random-shuffle.html)
* Use `shrink_to_fit` where possible - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-shrink-to-fit.html)
* Use `emplace` and its siblings where possible - [Link](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html) - Also note the options
* Use `empty` instead of `size` where possible - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html)
* Flag redundant calls to a smart pointers `get` method - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-smartptr-get.html) - Also note the option
* Flag redundant calls to `std::string::c_str` and `data` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-cstr.html)
* Flag redundant initializations of `std::string` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-init.html) - Also note the option
* Use comparison operators instead of `std::string`s comparison methods - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-string-compare.html)
* Use `nullptr` assignment instead of `delete std::unique_ptr::release` - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-uniqueptr-delete-release.html) - Also note the option
* Replace ranged `for` loops with `std::any_of` / `std::all_of` where possible - [Link](https://clang.llvm.org/extra/clang-tidy/checks/readability-use-anyofallof.html)

### Vote template

```markdown
Check | Yes | No | Comment
------|-----|----|--------
`std::to_string` instead of `boost::lexical_cast` | X | X | X
Inaccurate `erase` | X | X | X
Incorrect `strlen` in alloc | X | X | X
Misplaced pointer arithmetic in alloc | X | X | X
Don't use `move` instead of `forward` | X | X | X
Find non-null terminated `char*` ops | X | X | X
No reserved identifiers | X | X | X
Don't use `sizeof` on containers | X | X | X
Find suspicious `std::string` ctors | X | X | X
Find suspicios int-to-string assignments | X | X | X
Find suspicious `std::memset` | X | X | X
Find suspicious `std::strcmp` | X | X | X
Don't extend `namespace std` | X | X | X
Don't convert string to int without verification | X | X | X
No `setjmp` / `longjmp` | X | X | X
No `malloc` and siblings | X | X | X
No explicit template parameters in `std::make_pair` | X | X | X
No convoluted `unique_ptr` move | X | X | X
Use lambdas instead of `std::bind` | X | X | X
Avoid C arrays | X | X | X
Flag deprecated headers | X | X | X
Flag deprecated `ios_base` aliases | X | X | X
Use `std::make_shared` where possible | X | X | X
Use `std::make_unique` where possible | X | X | X
Replace `std::auto_ptr` | X | X | X
Replace `std::random_shuffle` | X | X | X
Use `shrink_to_fit` | X | X | X
Use `emplace` | X | X | X
Use `empty` instead of `size` | X | X | X
Flag redundant `smart_ptr::get` | X | X | X
Flag redundant `std::string::c_str` | X | X | X
Flag redundant `std::string` init | X | X | X
Use comparison operators on `std::string` | X | X | X
Use `nullptr` assignments to delete `unique_ptr` | X | X | X
Use `std::any_of` / `std::all_of` where possible | X | X | X
```

### Vote

Check | Yes | No | Comment
------|-----|----|--------
`std::to_string` instead of `boost::lexical_cast` | 1 | 0 | -
Inaccurate `erase` | 1 | 0 | -
Incorrect `strlen` in alloc | 1 | 0 | -
Misplaced pointer arithmetic in alloc | 1 | 0 | -
Don't use `move` instead of `forward` | 1 | 0 | -
Find non-null terminated `char*` ops | 1 | 0 | -
No reserved identifiers | 1 | 0 | -
Don't use `sizeof` on containers | 1 | 0 | -
Find suspicious `std::string` ctors | 1 | 0 | -
Find suspicios int-to-string assignments | 1 | 0 | -
Find suspicious `std::memset` | 1 | 0 | -
Find suspicious `std::strcmp` | 1 | 0 | -
Don't extend `namespace std` | 1 | 0 | -
Don't convert string to int without verification | 1 | 0 | -
No `setjmp` / `longjmp` | 1 | 0 | -
No `malloc` and siblings | 0 | 1 | -
No explicit template parameters in `std::make_pair` | 1 | 0 | -
No convoluted `unique_ptr` move | 1 | 0 | -
Use lambdas instead of `std::bind` | 1 | 0 | -
Avoid C arrays | 1 | 0 | -
Flag deprecated headers | 1 | 0 | -
Flag deprecated `ios_base` aliases | 1 | 0 | -
Use `std::make_shared` where possible | 1 | 0 | -
Use `std::make_unique` where possible | 1 | 0 | -
Replace `std::auto_ptr` | 1 | 0 | -
Replace `std::random_shuffle` | 1 | 0 | -
Use `shrink_to_fit` | 1 | 0 | -
Use `emplace` | 1 | 0 | -
Use `empty` instead of `size` | 1 | 0 | -
Flag redundant `smart_ptr::get` | 1 | 0 | -
Flag redundant `std::string::c_str` | 1 | 0 | -
Flag redundant `std::string` init | 1 | 0 | -
Use comparison operators on `std::string` | 1 | 0 | -
Use `nullptr` assignments to delete `unique_ptr` | 1 | 0 | -
Use `std::any_of` / `std::all_of` where possible | 1 | 0 | -