### PR TITLE
removed IndentPragmas from .clang-format

### DIFF
--- a/formatting-tools/.clang-format
+++ b/formatting-tools/.clang-format
@@ -55,7 +55,6 @@ IndentCaseLabels: false
 IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: AfterHash
-IndentPragmas: true
 IndentRequires: true
 IndentWidth: 4
 IndentWrappedFunctionNames: false


### PR DESCRIPTION
- the option was removed before the release of clang 12
- https://reviews.llvm.org/D92753

thanks to @bernhardmgruber for the hint