### PR TITLE
[clang-tidy] Vote: Add efficiency checks

### DIFF
--- a/formatting-tools/.clang-tidy
+++ b/formatting-tools/.clang-tidy
@@ -1,4 +1,5 @@
-Checks: 'boost-use-to-string,
+Checks: 'altera-struct-pack-align,
+boost-use-to-string,
 bugprone-assert-side-effect,
 bugprone-bool-pointer-implicit-conversion,
 bugprone-branch-clone,
@@ -95,6 +96,19 @@ modernize-use-nullptr,
 modernize-use-override,
 modernize-use-transparent-functors,
 modernize-use-using,
+performance-faster-string-find,
+performance-for-range-copy,
+performance-implicit-conversion-in-loop,
+performance-inefficient-algorithm,
+performance-inefficient-vector-operation,
+performance-move-const-arg,
+performance-move-constructor-init,
+performance-no-automatic-move,
+performance-noexcept-move-constructor,
+performance-trivially-destructible,
+performance-type-promotion-in-math-fn,
+performance-unnecessary-copy-initialization,
+performance-unnecessary-value-param,
 readability-avoid-const-params-in-decls,
 readability-const-return-type,
 readability-container-size-empty,
@@ -201,6 +215,15 @@ CheckOptions:
   - { key: modernize-use-override.AllowOverrideAndFinal, value: 1}
   - { key: modernize-use-transparent-functors.SafeMode, value: 1}
   - { key: modernize-use-using.IgnoreMacros, value: 0}
+  - { key: performance-faster-string-find.StringLikeClasses, value: "::std::basic_string;::std::basic_string_view"}
+  - { key: performance-for-range-copy.WarnOnAllAutoCopies, value: 1}
+  - { key: performance-for-range-copy.AllowedTypes, value: ""}
+  - { key: performance-inefficient-vector-operation.VectorLikeClasses, value: "::std::vector"}
+  - { key: performance-move-const-arg.CheckTriviallyCopyableMove, value: 1}
+  - { key: performance-move-constructor-init.IncludeStyle, value: "llvm"}
+  - { key: performance-unnecessary-copy-initialization.AllowedTypes, value: ""}
+  - { key: performance-unnecessary-value-param.IncludeStyle, value: "llvm"}
+  - { key: performance-unnecessary-value-param.AllowedTypes, value: ""}
   - { key: readability-else-after-return.WarnOnUnfixable, value: 1}
   - { key: readability-else-after-return.WarnOnConditionVariables, value: 1}
   - { key: readability-identifier-naming.AbstractClassCase, value: CamelCase}


### PR DESCRIPTION
Voting will close on 09 September EOD (German time).

* Find structs that are inefficiently packed and/or aligned - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/altera-struct-pack-align.html)
* Find inefficient calls to `std::string::find` - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-faster-string-find.html)
* Find unnecessary copies of loop variables in range for loops - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-for-range-copy.html)
* Find implicit copies in range for loops - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-implicit-conversion-in-loop.html)
* Find inefficient usages of `<algorithm>` - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-inefficient-algorithm.html)
* Find inefficient `std::string` concatenations - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-inefficient-string-concatenation.html). **Strict mode enabled**
* Find inefficient `std::vector` operations - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-inefficient-vector-operation.html)
* Find useless calls to `std::move` - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-move-const-arg.html)
* Find move constructors that initialize their base class or a member through a copy constructor - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-move-constructor-init.html)
* Find local variables that cannot automatically be moved upon `return` - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-no-automatic-move.html)
* Find move constructors / assignment operators without `noexcept` - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-noexcept-move-constructor.html)
* Find types that could be trivially destructible but aren't - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-trivially-destructible.html)
* Find implicit type promotions when using `<cmath>`- [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-type-promotion-in-math-fn.html)
* Find unnecessary copy initializations - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html)
* Find unnecessary copies that could be a `const&` - [Link](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-value-param.html)

### Vote template

```markdown
Check | Yes | No | Comment
------|-----|----|--------
Struct packing / alignment | X | X | X
`std::string::find` | X | X | X
Copies of loop vars in range for | X | X | X
Implicit copies in range for | X | X | X
Inefficient `<algorithm>` | X | X | X
Inefficient `std::string` concat | X | X | X
Inefficient `std::vector` ops | X | X | X
Useless `std::move` | X | X | X
copy ctors in move ctor | X | X | X
Unmovable local vars | X | X | X
Move ctors / assignments without `noexcept` | X | X | X
Types that should be trivially destructible | X | X | X
Type promotions in `<cmath>` | X | X | X
Unnecessary copy initializations | X | X | X
Unnecessary copies that could be `const&` | X | X | X
```

### Vote
Check | Yes | No | Comment
------|-----|----|--------
Struct packing / alignment | 1 | 0 | -
`std::string::find` | 1 | 0 | -
Copies of loop vars in range for | 1 | 0 | -
Implicit copies in range for | 1 | 0 | -
Inefficient `<algorithm>` | 1 | 0 | -
Inefficient `std::string` concat | 1 | 0 | -
Inefficient `std::vector` ops | 1 | 0 | -
Useless `std::move` | 1 | 0 | -
copy ctors in move ctor | 1 | 0 | -
Unmovable local vars | 1 | 0 | -
Move ctors / assignments without `noexcept` | 1 | 0 | -
Types that should be trivially destructible | 1 | 0 | -
Type promotions in `<cmath>` | 1 | 0 | -
Unnecessary copy initializations | 1 | 0 | -
Unnecessary copies that could be `const&` | 1 | 0 | -