### PR TITLE
Update to clang-format-16

### DIFF
--- a/formatting-tools/.clang-format
+++ b/formatting-tools/.clang-format
@@ -6,15 +6,16 @@ DisableFormat: false
 
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
+AlignArrayOfStructures: None
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: false
 AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: false
 AlignEscapedNewlines: Right
-AlignOperands: DontAlign
-AlignTrailingComments: false
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Never
 AllowAllArgumentsOnNextLine: false
-AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
@@ -29,9 +30,11 @@ AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
 BitFieldColonSpacing: Both
+BreakAfterAttributes: Never
 BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Allman
-BreakBeforeConceptDeclarations: true
+BreakBeforeConceptDeclarations: Always
+BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: BeforeComma
@@ -39,47 +42,69 @@ BreakStringLiterals: true
 ColumnLimit: 119
 CommentPragmas:  '^ COMMENT pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DeriveLineEnding: true
 DerivePointerAlignment: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: Always
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 IncludeBlocks: Regroup
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
 IndentCaseBlocks: true
 IndentCaseLabels: false
 IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: AfterHash
-IndentRequires: true
+IndentRequiresClause: false
 IndentWidth: 4
 IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertNewlineAtEOF: true
+IntegerLiteralSeparator:
+  Binary: 4
+  Decimal: 3
+  DecimalMinDigits: 7
+  Hex: 4
 KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+LineEnding: DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: All
-AlignOperands: Align
+PackConstructorInitializers: CurrentLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0 # default made explicit here
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0 # default made explicit here
 PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Left
-QualifierAlignment: Right
+PPIndentWidth: -1 # follow IndentWidth
+QualifierAlignment: Custom
+QualifierOrder: ['friend', 'inline', 'static', 'constexpr', 'type', 'const', 'volatile', 'restrict']
+ReferenceAlignment: Pointer # follow PointerAlignment
 ReflowComments: true
+RemoveBracesLLVM: false
+RemoveSemicolon: false
+RequiresClausePosition: WithPreceding
+RequiresExpressionIndentation: OuterScope
+ShortNamespaceLines: 0
 SortIncludes: true
-SortUsingDeclarations: true
+SortUsingDeclarations: Lexicographic
+SeparateDefinitionBlocks: Always
 SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default # follow PointerAlignment
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
@@ -87,6 +112,7 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: Never
 SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
@@ -94,14 +120,19 @@ SpacesInAngles:  false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpaceBeforeSquareBrackets: false
 TabWidth: 4
 UseCRLF: false
 UseTab: Never
 
 # Project specific options -- uncomment and modify as needed
+#AttributeMacros: []
+#ForEachMacros: []
+#IfMacros: []
 #IncludeCategories:
 #  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
 #    Priority:        2
@@ -112,6 +143,10 @@ UseTab: Never
 #  - Regex:           '.*'
 #    Priority:        1
 #    SortPriority:    0
+#NamespaceMacros: []
 #StatementAttributeLikeMacros: []
+#StatementMacros: []
+#TypenameMacros: []
+#WhitespaceSensitiveMacros: []
 
 ...


### PR DESCRIPTION
It has been a while since we updated the clang-format style. This PR adds the rules added to clang-format since the last overhaul and removes those which are deprecated. I tried to follow the existing (manual) alpaka style where possible but we should vote on the changes.

### New rules (value after name = current proposed setting):
* AlignArrayOfStructures (`Left`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#alignarrayofstructures)
* BreakAfterAttributes (`Never`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#breakafterattributes)
* BreakBeforeConceptDeclarations (`Always`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#breakbeforeconceptdeclarations)
* BreakBeforeInlineASMColon (`Always`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#breakbeforeinlineasmcolon)
* EmptyLineAfterAccessModifier (`Never`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#emptylineafteraccessmodifier)
* EmptyLineBeforeAccessModifier (`Always`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#emptylinebeforeaccessmodifier)
* IndentAccessModifiers (`false`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#indentaccessmodifiers)
* IndentRequiresClause (`false`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#indentrequiresclause)
* InsertBraces (`true`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertbraces)
* InsertNewlineAtEOF (`true`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertnewlineateof)
* IntegerLiteralSeparator (`Binary: 4, Decimal: 3, Hex: 4`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#integerliteralseparator)
* LambdaBodyIndentation (`Signature`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#lambdabodyindentation)
* PenaltyBreakOpenParentheses (`2`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#penaltybreakopenparenthesis)
* PenaltyIndentedWhitespace (`2`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#penaltyindentedwhitespace)
* PPIndentWidth (`-1`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#ppindentwidth)
* QualifierAlignment (`Custom`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#qualifieralignment)
* QualifierOrder (`['friend', 'inline', 'static', 'constexpr', 'type', 'const', 'volatile', 'restrict']`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#qualifierorder)
* ReferenceAlignment (`Pointer`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#referencealignment)
* RemoveBracesLLVM (`false`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#removebracesllvm)
* RemoveSemicolon (`true`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#removesemicolon)
* RequiresClausePosition (`WithPreceding`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#requiresclauseposition)
* RequiresExpressionIndentation (`Keyword`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#requiresexpressionindentation)
* ShortNamespaceLines (`0`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#shortnamespacelines)
* SeparateDefinitionBlocks (`Always`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#separatedefinitionblocks)
* SpaceAroundPointerQualifiers (`Default`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#spacearoundpointerqualifiers)
* SpaceBeforeSquareBrackets (`false`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#spacebeforesquarebrackets)
* SpacesInLineCommentPrefix (`Minimum: 1, Maximum: -1`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#spacesinlinecommentprefix)

### Replacements:

* AlignTrailingComments (`Never`) - replaces old-style AlignTrailingComments (`false`) - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#aligntrailingcomments)
* LineEnding (`DeriveLF`) - replaces DeriveLineEnding - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#lineending)
* PackConstructorInitializers (`CurrentLine`) - replaces AllowAllConstructorInitializersOnNextLine and ConstructorInitializerAllOnOneLineOrOnePerLine - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#packconstructorinitializers)

### New project-specific options:

* AttributeMacros - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#attributemacros)
* IfMacros - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#ifmacros)
* WhitespaceSensitiveMacros - [Link](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#whitespacesensitivemacros)